### PR TITLE
Fix ritual blade conditions

### DIFF
--- a/Arcana/mod_interactions/magiclysm/conditions_for_eocs.json
+++ b/Arcana/mod_interactions/magiclysm/conditions_for_eocs.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_CONDITION_XE_ARCANA_VEILBLADE_MUTANT",
+    "id": "EOC_CONDITION_MAGICLYSM_ARCANA_VEILBLADE_MUTANT",
     "condition": {
       "or": [
         {
@@ -21,7 +21,9 @@
             { "u_has_trait": "LIZARDFOLK_BUILD" },
             { "math": [ "u_sum_traits_of_category_char_has('SPECIES_LIZARDFOLK') <= 12" ] }
           ]
-        }
+        },
+        { "math": [ "u_sum_traits_of_category_char_has('DRAGON_BLACK') - mana_mutations_exemption() >= 5" ] },
+        { "math": [ "u_sum_traits_of_category_char_has('MANATOUCHED') - mana_mutations_exemption() >= 5" ] }
       ]
     },
     "effect": [  ]

--- a/Arcana/mod_interactions/magiclysm/conditions_for_eocs.json
+++ b/Arcana/mod_interactions/magiclysm/conditions_for_eocs.json
@@ -22,8 +22,8 @@
             { "math": [ "u_sum_traits_of_category_char_has('SPECIES_LIZARDFOLK') <= 12" ] }
           ]
         },
-        { "math": [ "u_sum_traits_of_category_char_has('DRAGON_BLACK') - mana_mutations_exemption() >= 5" ] },
-        { "math": [ "u_sum_traits_of_category_char_has('MANATOUCHED') - mana_mutations_exemption() >= 5" ] }
+        { "math": [ "(u_sum_traits_of_category_char_has('DRAGON_BLACK') - mana_mutations_exemption() ) >= 5" ] },
+        { "math": [ "(u_sum_traits_of_category_char_has('MANATOUCHED') - mana_mutations_exemption() ) >= 5" ] }
       ]
     },
     "effect": [  ]

--- a/Arcana/mod_interactions/magiclysm/jmath.json
+++ b/Arcana/mod_interactions/magiclysm/jmath.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "mana_mutations_exemption",
+    "type": "jmath_function",
+    "num_args": 0,
+    "return": "u_has_trait('MANA_ADD1') + u_has_trait('MANA_ADD2') + u_has_trait('MANA_REGEN1') + u_has_trait('MANA_REGEN2') + u_has_trait('BAD_MANA_REGEN1') + u_has_trait('MANA_MULT1') + u_has_trait('MANA_MULT2') + u_has_trait('BAD_MANA_MULT1')"
+  }
+]

--- a/Arcana/mod_interactions/mindovermatter/conditions_for_eocs.json
+++ b/Arcana/mod_interactions/mindovermatter/conditions_for_eocs.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_MOM_ARCANA_VEILBLADE_TELEPORTER",
+    "condition": { "u_has_trait": "TELEPORTER" },
+    "effect": [  ]
+  }
+]

--- a/Arcana/mod_interactions/xedra_evolved/condition_eocs.json
+++ b/Arcana/mod_interactions/xedra_evolved/condition_eocs.json
@@ -2,7 +2,11 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CONDITION_XE_ARCANA_VEILBLADE_MUTANT",
-    "condition": { "or": [ { "math": [ "u_sum_traits_of_category_char_has('MANATOUCHED') >= 3" ] } ] },
+    "condition": {
+      "or": [
+        { "u_has_any_trait": [ "CHANGELING_MAGIC", "ARVORE", "HOMULLUS", "IERDE", "SALAMANDER", "SYLPH", "UNDINE", "GRACKEN" ] }
+      ]
+    },
     "effect": [  ]
   },
   {

--- a/Arcana/spells/spells_react.json
+++ b/Arcana/spells/spells_react.json
@@ -433,6 +433,7 @@
       "or": [
         { "test_eoc": "EOC_CONDITION_XE_ARCANA_VEILBLADE_MUTANT" },
         { "test_eoc": "EOC_CONDITION_MAGICLYSM_ARCANA_VEILBLADE_MUTANT" },
+        { "test_eoc": "EOC_CONDITION_MOM_ARCANA_VEILBLADE_TELEPORTER" },
         { "and": [ { "u_has_flag": "MUTATION_THRESHOLD" }, { "not": { "u_has_trait": "THRESH_VEIL" } } ] },
         { "math": [ "u_sum_traits_of_category_char_has('ALPHA') >= 5" ] },
         { "math": [ "u_sum_traits_of_category_char_has('BATRACHIAN') >= 5" ] },
@@ -479,6 +480,12 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CONDITION_XE_ARCANA_VEILBLADE_MUTANT",
+    "condition": { "math": [ "0 == 1" ] },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_MOM_ARCANA_VEILBLADE_TELEPORTER",
     "condition": { "math": [ "0 == 1" ] },
     "effect": [  ]
   },

--- a/Arcana/spells/spells_react.json
+++ b/Arcana/spells/spells_react.json
@@ -422,6 +422,7 @@
     "description": "This punishes you if you're a mutant and try to use the veilblade.",
     "valid_targets": [ "self" ],
     "flags": [ "SILENT" ],
+    "skill": "magic",
     "effect": "effect_on_condition",
     "effect_str": "EOC_ARCANA_VEILBLADE_MUTANT",
     "shape": "blast"

--- a/Arcana/spells/spells_react.json
+++ b/Arcana/spells/spells_react.json
@@ -457,7 +457,7 @@
         { "math": [ "u_sum_traits_of_category_char_has('MOUSE') >= 5" ] },
         { "math": [ "u_sum_traits_of_category_char_has('MYCUS') >= 1" ] },
         { "math": [ "u_sum_traits_of_category_char_has('PLANT') >= 5" ] },
-        { "math": [ "u_sum_traits_of_category_char_has('RABBIT') >= 1" ] },
+        { "math": [ "u_sum_traits_of_category_char_has('RABBIT') >= 5" ] },
         { "math": [ "u_sum_traits_of_category_char_has('RAPTOR') >= 5" ] },
         { "math": [ "u_sum_traits_of_category_char_has('RAT') >= 5" ] },
         { "math": [ "u_sum_traits_of_category_char_has('SLIME') >= 5" ] },


### PR DESCRIPTION
The restored ritual blade has been zapping people when it shouldn't and not zapping people when it should.

1) Actually make Magiclysm conditions work. Check for Black Dragon and Manatouched mutations (minus the mana traits anyone can get). 
2) Add MoM condition--HfBtV hates Teleporters
3) Fix XE conditions--extradimensional beings, Fair Folks and gracken, can't use it at all. Vampire are fine (they're local threats). 