### PR TITLE
Remove atomic lamp from item group

### DIFF
--- a/Arcana/item_groups/item_groups_general.json
+++ b/Arcana/item_groups/item_groups_general.json
@@ -70,8 +70,7 @@
       { "item": "flashlight", "prob": 15 },
       { "item": "wearable_light", "prob": 15 },
       { "item": "electric_lantern", "prob": 10 },
-      { "item": "gasoline_lantern", "prob": 10 },
-      { "item": "atomic_lamp", "prob": 1 }
+      { "item": "gasoline_lantern", "prob": 10 }
     ]
   },
   {


### PR DESCRIPTION
Atomic lamps no longer exist