### PR TITLE
Add Cloak of Undergrowth to the natural shrine item pool

### DIFF
--- a/Arcana/effects/effects_items.json
+++ b/Arcana/effects/effects_items.json
@@ -14,5 +14,40 @@
     "name": [ "" ],
     "desc": [ "" ],
     "blocks_effects": [ "tpollen", "fungus", "poison", "badpoison", "venom_weaken", "venom_pain", "venom_dmg" ]
+  },
+  {
+    "id": "effect_arcana_cloak_nature_hide",
+    "type": "effect_type",
+    "//": "Hidden effect, applied by the cloak of the undergrowth",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            {
+              "or": [
+                { "not": { "u_near_om_location": "road", "range": 2 } },
+                {
+                  "and": [
+                    { "u_near_om_location": "road", "range": 2 },
+                    { "or": [ { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ] }
+                  ]
+                }
+              ]
+            },
+            {
+              "or": [
+                { "u_is_on_terrain_with_flag": "SHRUB" },
+                { "u_is_on_terrain_with_flag": "YOUNG" },
+                { "u_is_on_terrain_with_flag": "DIGGABLE" },
+                { "u_is_on_terrain_with_flag": "GRAZABLE" }
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "STEALTH_MODIFIER", "add": 50 } ]
+      }
+    ]
   }
 ]

--- a/Arcana/item_groups/item_groups_shrines.json
+++ b/Arcana/item_groups/item_groups_shrines.json
@@ -13,7 +13,7 @@
     "id": "arcana_wilderness_nature_shrine_loot",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "crown_of_ivy", "prob": 20 } ]
+    "entries": [ { "item": "crown_of_ivy", "prob": 20 }, { "item": "cloak_nature_hide", "prob": 20 } ]
   },
   {
     "id": "arcana_wilderness_flesh_shrine_loot",

--- a/Arcana/items/armor/body.json
+++ b/Arcana/items/armor/body.json
@@ -51,13 +51,72 @@
     }
   },
   {
+    "id": "cloak_nature_hide",
+    "copy-from": "cloak",
+    "looks_like": "grass_cloak",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "name": { "str": "cloak of undergrowth", "str_pl": "cloaks of undergrowth" },
+    "description": "A cloak of leaves, somehow still fresh and green despite being woven into a garment.  Activate it to subsume your presence into the wilds, making you harder to spot while out in nature.",
+    "weight": "1175 g",
+    "volume": "3 L",
+    "price": "5000 USD",
+    "price_postapoc": "50 USD",
+    "material": [ "veggy" ],
+    "charges_per_use": 1,
+    "tool_ammo": "essence_natural_type",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_natural_type": 30 } } ],
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ACTIVE",
+        "ench_effects": [ { "effect": "effect_arcana_cloak_nature_hide", "intensity": 1 } ]
+      }
+    ],
+    "use_action": [
+      {
+        "target": "cloak_nature_hide_on",
+        "msg": "The leaves on the cloak rustle soundlessly.",
+        "need_worn": true,
+        "need_charges": 1,
+        "need_charges_msg": "The cloak requires essence to conceal you.",
+        "menu_text": "Hide in the wilds",
+        "type": "transform",
+        "ammo_scale": 0
+      }
+    ]
+  },
+  {
+    "id": "cloak_nature_hide_on",
+    "copy-from": "cloak_nature_hide",
+    "repairs_like": "cloak_nature_hide",
+    "looks_like": "grass_cloak",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "category": "armor",
+    "name": { "str": "cloak of undergrowth (on)", "str_pl": "cloaks of undergrowth (on)" },
+    "description": "A cloak of leaves, somehow still fresh and green despite being woven into a garment.  Activate it to subsume your presence into the wilds, making you harder to spot while out in nature.  It is currently hiding you.",
+    "turns_per_charge": 180,
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
+    "revert_to": "cloak_nature_hide",
+    "revert_msg": "The cloak leaves rustle with a soft sound.",
+    "use_action": [
+      {
+        "target": "cloak_nature_hide",
+        "msg": "The leaves on the cloak rustle.",
+        "menu_text": "Turn off",
+        "type": "transform",
+        "ammo_scale": 0
+      }
+    ]
+  },
+  {
     "id": "robe_shadow",
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "copy-from": "robe",
     "category": "armor",
     "name": { "str": "mantle of shadows", "str_pl": "mantles of shadows" },
-    "//": "misc properties were mostly made by averaging the values of all possible types of robe usable to make it, but no storage due to nested containers being buggy",
     "description": "A loose-fitting robe of some sort, heavily altered with decorations resting on the shoulders, dyed in a simple dark gray.  Activating it will grant invisibility, constantly draining essence while in use.",
     "price": "900 USD",
     "price_postapoc": "70 USD",


### PR DESCRIPTION
As title. When active, the Cloak of the Undergrowth lets you hide much more easily in wild places (reduced range at which monsters spot you). 