### PR TITLE
Override bloody blade weapon categories to add `SHRIKE_WEAPONRY`

### DIFF
--- a/Arcana/items/ethereal_items.json
+++ b/Arcana/items/ethereal_items.json
@@ -45,6 +45,7 @@
     "name": { "str": "bloody blade" },
     "description": "A sword made of blood, still visibly flowing and warm in your hand.",
     "material": [ { "type": "blood", "portion": 1 } ],
+    "weapon_category": [ "LONG_SWORDS", "LONG_THRUSTING_SWORDS", "SHRIKE_WEAPONRY" ],
     "extend": { "flags": [ "NO_DROP", "NO_REPAIR", "UNBREAKABLE_MELEE", "RELIC_PINK", "TRADER_AVOID" ] },
     "techniques": [ "WBLOCK_2", "BRUTAL", "RAPID", "tec_weapon_blood_sword_bleeding" ],
     "passive_effects": [


### PR DESCRIPTION
Despite being a longsword, it's literally a sword made out of blood using blood magic so the shrikes should be able to use it with their arts if they know any blood magic. 