### PR TITLE
Fix Strange Maps

### DIFF
--- a/Arcana/items/books.json
+++ b/Arcana/items/books.json
@@ -530,6 +530,7 @@
     "symbol": ";",
     "looks_like": "survivormap",
     "color": "white",
+    "flags": [ "PRESERVE_SPAWN_LOC", "LOCATION_PRECISE_CLOSEST_CITY" ],
     "use_action": {
       "type": "reveal_map",
       "radius": 180,


### PR DESCRIPTION
Strange Maps were missing a reference to their spawn location and nearest city, making them unusable. This fixes that.

It will _not_ allow previously-found strange maps to work. 