### PR TITLE
Fix well dressed feral death drops

### DIFF
--- a/Arcana/item_groups/monster_drops.json
+++ b/Arcana/item_groups/monster_drops.json
@@ -1024,6 +1024,7 @@
   },
   {
     "id": "feral_fancy_death_drops_rapier",
+    "copy-from": "feral_fancy_death_drops_rapier",
     "//": "Orphaned Item group",
     "type": "item_group",
     "subtype": "collection",
@@ -1031,6 +1032,7 @@
   },
   {
     "id": "feral_fancy_death_drops_rapier_fake",
+    "copy-from": "feral_fancy_death_drops_rapier_fake",
     "//": "Orphaned Item group",
     "type": "item_group",
     "subtype": "collection",


### PR DESCRIPTION
Well dressed ferals were dropping nothing.
I noticed that it was because their death drops didn't have copy-from, this fixes it.